### PR TITLE
Provision Bluemix data services

### DIFF
--- a/lib/cf.js
+++ b/lib/cf.js
@@ -461,25 +461,32 @@ function getDataServiceInstances(parent, accessToken, options, cb) {
  * @param cb {function} Callback function
  */
 function getSupportedServices(parent, accessToken, options, cb) {
-  if (typeof options === 'function' && cb === undefined) {
+  if (typeof options === 'function') {
     cb = options;
     options = {};
   }
-  getServices(parent, accessToken, options, function(err, services) {
-    if (err) return cb(err);
-    var supportedServices = {};
-    services.forEach(function(resource) {
-      var label = resource.entity.label;
-      if (bluemixSupportedServiceLabels.indexOf(label) > -1) {
-        supportedServices[label] = {};
-        var service = supportedServices[label];
-        service.guid = resource.metadata.guid;
-        service.url = resource.metadata.url;
-        service.plansUrl = resource.entity['service_plans_url'];
+  var services = [];
+  var supportedServices = [];
+  function getMarketplace(url) {
+    return invokeResource(url, accessToken, options, function(err, res) {
+      if (err) return cb(err);
+      services = services.concat(res.body.resources);
+      if (res.body.next_url) {
+        getMarketplace(res.body.next_url);
+      } else {
+        services.forEach(function(service) {
+          if (bluemixSupportedServiceLabels.indexOf(service.entity.label) > -1) {
+            supportedServices.push(service.entity);
+          }
+        });
+        cb(null, supportedServices);
       }
     });
-    cb(null, supportedServices);
-  });
+  }
+
+  var cfConfig = getCfConfig();
+  var url = '/v2/spaces/' + cfConfig.space.guid + '/services';
+  return getMarketplace(url);
 }
 
 /**

--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -30,7 +30,6 @@ function selectBluemixDatasource(datasource, globalize) {
     if (err) return done(err);
     if (resources.length < 1) {
       datasource.log('No Bluemix data service instances found.');
-      return done();
     }
     var serviceChoices = [];
     var appDatasourcesConfigFilePath = path.resolve('.bluemix',
@@ -43,8 +42,8 @@ function selectBluemixDatasource(datasource, globalize) {
     var existingBluemixDatasources = appDatasourcesConfig.datasources;
     var existingBluemixDatasourcesKeys = Object
                                         .keys(existingBluemixDatasources);
-    if (existingBluemixDatasourcesKeys.length > 1) {
-      datasource.log('\n Already added:\n');
+    if (existingBluemixDatasourcesKeys.length > 0) {
+      datasource.log('\n Already added:');
       existingBluemixDatasourcesKeys.forEach(function(name) {
         if (name !== 'db') {
           datasource.log(chalk.yellow(' ∙ ' + name));
@@ -52,9 +51,8 @@ function selectBluemixDatasource(datasource, globalize) {
       });
     }
 
-    if (existingBluemixDatasourcesKeys.length === resources.length) {
+    if (resources.length && existingBluemixDatasourcesKeys.length === resources.length) {
       datasource.log('All datasource services already added.');
-      return done();
     }
     var services = {};
     var _connectorChoices = datasource.listOfAvailableConnectors;
@@ -81,13 +79,12 @@ function selectBluemixDatasource(datasource, globalize) {
       }
     });
 
-    // TODO: uncomment to enable data service provisioning
-    // serviceChoices.push('Provision a new service ▶︎');
+    serviceChoices.push('Provision a new service ▶︎');
 
     var prompts = [
       {
         name: 'serviceName',
-        message: globalize.f('Select the Bluemix datasource service'),
+        message: globalize.f('Select the Bluemix datasource option'),
         type: 'list',
         choices: serviceChoices,
       },
@@ -115,8 +112,11 @@ function selectBluemixDatasource(datasource, globalize) {
 function promptServiceName(datasource, globalize) {
   var done = datasource.async();
   var serviceTypes = [];
+  var connectorNameLookup = {};
   Object.keys(bluemixSupportedServices).forEach(function(k) {
-    serviceTypes.push(bluemixSupportedServices[k]);
+    var label = bluemixSupportedServices[k].label;
+    serviceTypes.push(label);
+    connectorNameLookup[label] = k;
   });
   var prompts = [
     {
@@ -131,8 +131,9 @@ function promptServiceName(datasource, globalize) {
     },
   ];
   return datasource.prompt(prompts).then(function(answers) {
-    datasource.serviceName = answers.serviceName;
+    datasource.name = answers.serviceName;
     datasource.serviceType = answers.serviceType;
+    datasource.connector = connectorNameLookup[answers.serviceType];
     return done();
   }.bind(datasource));
 }
@@ -143,9 +144,13 @@ function promptServiceName(datasource, globalize) {
  */
 function getServicePlans(datasource) {
   var done = datasource.async();
+  console.log('  Getting service plans...');
   cf.getSupportedServices(null, datasource.accessToken, function(err, serviceDetails) {
     if (err) return done(err);
-    datasource.dataServices = serviceDetails;
+    datasource.dataServices = {};
+    serviceDetails.forEach(function(service) {
+      datasource.dataServices[service.label] = service;
+    });
     return done();
   });
 }
@@ -159,9 +164,10 @@ function promptServicePlan(datasource, globalize) {
   var done = datasource.async();
   var service = datasource.dataServices[datasource.serviceType];
   datasource.servicePlans = {};
-  cf.getServicePlans(null, datasource.accessToken, service.plansUrl,
-  function(err, servicePlans) {
+  cf.getResource(service.service_plans_url, datasource.accessToken, {},
+  function(err, res) {
     if (err) return done(err);
+    var servicePlans = res.body.resources;
     servicePlans.forEach(function(plan) {
       datasource.servicePlans[plan.entity.name] = plan.metadata.guid;
     });
@@ -185,14 +191,16 @@ function provisionService(datasource, globalize) {
       choices: servicePlans,
     },
   ];
+  var cfConfig = cf.getCfConfig();
   return datasource.prompt(prompts).then(function(answers) {
     var details = {};
-    details.name = datasource.serviceName;
+    details.name = datasource.name;
     details['service_plan_guid'] = datasource.servicePlans[answers.servicePlan];
-    details['space_guid'] = datasource.space.guid;
-    cf.provisionService(datasource.accessToken, details, function(err, res, service) {
+    details['space_guid'] = cfConfig.space.guid;
+    cf.provisionService(datasource.accessToken, details, function(err, res) {
       if (err) return done(err);
-      datasource.serviceGUID = service.metadata.guid;
+      var service = res.body;
+      datasource.serviceGuid = service.metadata.guid;
       return done();
     });
   }.bind(datasource));
@@ -213,7 +221,7 @@ function bindServiceToApp(datasource) {
         matchedApp = true;
         var details = {
           'app_guid': app.metadata.guid,
-          'service_instance_guid': datasource.serviceGUID,
+          'service_instance_guid': datasource.serviceGuid,
         };
         cf.bindService(datasource.accessToken, details, function(err) {
           return done(err);


### PR DESCRIPTION
This PR adds:

- Service provisioning capability while adding a new Bluemix datasource (currently limited to Cloudant and MongoDB)
- Bind the provisioned service to the app, IF the app is already deployed on Bluemix

