### PR TITLE
Fixed missing datasources.bluemix.js

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -23,6 +23,13 @@ module.exports = function(bluemixOptions, copyFile, copyDir) {
   var bluemixDirSrc = path.resolve(bluemixTemplatesDir, 'bluemix');
   var bluemixDirDest = path.resolve(bluemixOptions.destDir, '.bluemix');
 
+  // Create datasources.bluemix.js
+  var datasourceBluemixSrc = path.resolve(bluemixTemplatesDir,
+                              'datasources.bluemix.js');
+  var datasourceBluemixDest = path.resolve(bluemixOptions.destDir, 'server',
+                              'datasources.bluemix.js');
+  copyFile(datasourceBluemixSrc, datasourceBluemixDest);
+
   if (bluemixOptions.enableBluemix) {
     // Create .cfignore
     var cfignoreSrc = path.resolve(bluemixTemplatesDir, 'cfignore');
@@ -41,12 +48,6 @@ module.exports = function(bluemixOptions, copyFile, copyDir) {
       copyFile(readmeSrc, readmeDest);
     }
 
-    // Create datasources.bluemix.js
-    var datasourceBluemixSrc = path.resolve(bluemixTemplatesDir,
-                                'datasources.bluemix.js');
-    var datasourceBluemixDest = path.resolve(bluemixOptions.destDir, 'server',
-                                'datasources.bluemix.js');
-    copyFile(datasourceBluemixSrc, datasourceBluemixDest);
     // Copy datasource-config.json
     var datasourceConfigSrc = path.join(bluemixDirSrc, 'datasources-config.json');
     var datasourceConfigDest = path.join(bluemixDirDest, 'datasources-config.json');

--- a/test/files.test.js
+++ b/test/files.test.js
@@ -14,7 +14,6 @@ var sandboxDir = path.resolve(__dirname, 'sandbox');
 
 var BASIC_BLUEMIX_FILES = [
   '.bluemix/datasources-config.json',
-  'server/datasources.bluemix.js',
   '.cfignore',
   'manifest.yml',
 ];
@@ -41,7 +40,20 @@ describe('lib/files', function() {
     fs.removeSync(sandboxDir);
   });
 
-  it('should generate Bluemix files', function() {
+  it('should generate datasources.bluemix.js', function() {
+    var options = {
+      destDir: sandboxDir,
+      enableBluemix: false,
+      enableManifest: false,
+      enableDocker: false,
+      enableToolchain: false,
+    };
+    lbBM.generateBluemixFiles(options, fs.copySync, fs.copySync);
+    var filePath = sandboxDir + '/server/datasources.bluemix.js';
+    assert(fs.existsSync(filePath));
+  });
+
+  it('should generate basic Bluemix files', function() {
     var options = {
       destDir: sandboxDir,
       enableBluemix: true,


### PR DESCRIPTION
`datasources.bluemix.js` was not being created under some conditions, when called with `lb bluemix`.  This file should be created irrespective of other conditions.