### PR TITLE
Consistent use of serviceGuid

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -92,7 +92,7 @@ function selectBluemixDatasource(datasource, globalize) {
       var service = services[datasource.name];
       if (!service) return done(new Error('Invalid service: ' + datasource.name));
       datasource.connector = service.connector;
-      datasource.serviceGUID = service.guid;
+      datasource.serviceGuid = service.guid;
       return done();
     }.bind(datasource));
   });

--- a/test/datasource.test.js
+++ b/test/datasource.test.js
@@ -91,7 +91,7 @@ describe('lib/datasource', function() {
           if (err) return done(err);
           assert('cloudantFixture' === datasource.name);
           assert('cloudant' === datasource.connector);
-          assert('serviceGUID' in datasource);
+          assert('serviceGuid' in datasource);
           done();
         };
       };


### PR DESCRIPTION
An instance of `serviceGUID` remained, which caused `serviceGuid` to  be `undefined`.